### PR TITLE
feat: make parent slug 0 instead of empty string as typesense can't f…

### DIFF
--- a/app/Collections/Taxonomy.php
+++ b/app/Collections/Taxonomy.php
@@ -98,7 +98,7 @@ class Taxonomy extends BaseCollection {
 			'bannerThumbnail' => (string) $bannerThumbnail,
 			'bannerText' => $bannerText,
 			'parentTerm' => $parentTerm->name ? $parentTerm->name : '',
-			'parentSlug' => $parentTerm->slug ? $parentTerm->slug : '',
+			'parentSlug' => $parentTerm->slug ? $parentTerm->slug : '0',
 			'productCount' => (int) $term->count,
 			'order' => (int) $order,
 			'thumbnail' => $thumbnail,


### PR DESCRIPTION
Make parent slug 0 if its empty since typesense cannot filter empty string and cause us not being able to filter taxonomy when there are no parent